### PR TITLE
Add the unikernel

### DIFF
--- a/unikernel/config.ml
+++ b/unikernel/config.ml
@@ -1,0 +1,66 @@
+open Mirage
+
+let remote =
+  let doc = Key.Arg.info ~doc:"Remote Git repository." [ "r"; "remote" ] in
+  Key.(create "remote" Arg.(required string doc))
+
+let ssh_key =
+  let doc = Key.Arg.info ~doc:"Seed of the private SSH key." [ "ssh-key" ] in
+  Key.(create "ssh-key" Arg.(opt (some string) None doc))
+
+let ssh_auth =
+  let doc = Key.Arg.info ~doc:"SSH public key of the remote Git endpoint." [ "ssh-auth" ] in
+  Key.(create "ssh-auth" Arg.(opt (some string) None doc))
+
+let pass =
+  let doc = Key.Arg.info ~doc:"Pass-phrase to reload the Git repository." [ "pass" ] in
+  Key.(create "pass" Arg.(required string doc))
+
+let production =
+  let doc = Key.Arg.info ~doc:"Production certificate." [ "production" ] in
+  Key.(create "production" Arg.(opt bool false doc))
+
+let email =
+  let doc = Key.Arg.info ~doc:"Let's encrypt email." [ "email" ] in
+  Key.(create "email" Arg.(opt (some string) None doc))
+
+let account_seed =
+  let doc = Key.Arg.info ~doc:"Let's encrypt account seed." [ "account-seed" ] in
+  Key.(create "account_seed" Arg.(opt (some string) None doc))
+
+let certificate_seed =
+  let doc = Key.Arg.info ~doc:"Let's encrypt certificate seed." [ "certificate-seed" ] in
+  Key.(create "certificate_seed" Arg.(opt (some string) None doc))
+
+let contruno =
+  foreign "Unikernel.Make"
+    ~keys:[ Key.v remote
+          ; Key.v pass
+          ; Key.v production
+          ; Key.v email
+          ; Key.v account_seed
+          ; Key.v certificate_seed ]
+    (random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> git_client @-> job)
+
+let random = default_random
+let mclock = default_monotonic_clock
+let pclock = default_posix_clock
+let time = default_time
+let stack = generic_stackv4v6 default_network
+
+let git =
+  let dns_client = generic_dns_client stack in
+  let git = git_happy_eyeballs stack dns_client (generic_happy_eyeballs stack dns_client) in
+  let tcp = tcpv4v6_of_stackv4v6 stack in
+  git_ssh ~key:ssh_key ~authenticator:ssh_auth tcp git
+
+let packages =
+  [ package "contruno"
+  ; package "paf"
+  ; package "irmin-mirage-git" ~min:"2.10.2" ~max:"3.0.0"
+  ; package "paf-le" ]
+
+let () =
+  register "contruno"
+    ~packages
+    [ contruno $ random $ time $ mclock $ pclock $ stack $ git ]

--- a/unikernel/unikernel.ml
+++ b/unikernel/unikernel.ml
@@ -1,0 +1,34 @@
+open Rresult
+open Lwt.Infix
+
+let ( <.> ) f g = fun x -> f (g x)
+
+module Make
+  (Random : Mirage_random.S)
+  (Time : Mirage_time.S)
+  (Mclock : Mirage_clock.MCLOCK)
+  (Pclock : Mirage_clock.PCLOCK)
+  (Stack : Tcpip.Stack.V4V6)
+  (_ : sig end)
+= struct
+  include Contruno.Make (Random) (Time) (Mclock) (Pclock) (Stack)
+
+  let error_handler _peer ?request:_ _error _write = ()
+
+  let start _random _time () () stackv4v6 ctx =
+    let http = Lwt_mutex.create () in
+    let cfg  = { Contruno.production= Key_gen.production ()
+               ; email= Option.bind (Key_gen.email ()) (R.to_option <.> Emile.of_string)
+               ; account_seed= Key_gen.account_seed ()
+               ; certificate_seed= Key_gen.certificate_seed () } in
+    initialize http ~ctx ~remote:(Key_gen.remote ()) cfg stackv4v6 >>= fun (conns, tree, ths) ->
+    let service = serve conns tree ~error_handler (Stack.tcp stackv4v6) in
+    add_hook ~pass:(Key_gen.pass ()) ~ctx ~remote:(Key_gen.remote ()) tree stackv4v6 ;
+    init ~port:443 stackv4v6 >>= fun stack ->
+    let stop = Lwt_switch.create () in
+    let `Initialized th = Paf.serve ~sleep:Time.sleep_ns ~stop service stack in
+    Lwt.both
+      (Lwt_list.iter_p (fun (`Ready th) -> th) ths >>= fun () -> Lwt_switch.turn_off stop)
+      (Lwt.both th (Stack.listen stackv4v6)) >>= fun ((), ((), ())) ->
+    Lwt.return_unit
+end


### PR DESCRIPTION
However, with MirageOS 4, we must split the distribution between the
library and the unikernel because `dune` has some trouble with the
`contruno` fetched by `opam monorepo` and this one