### PR TITLE
Use own_cert instead of a specific certificate along contruno

### DIFF
--- a/contruno.opam
+++ b/contruno.opam
@@ -25,12 +25,7 @@ depends: [
   "mirage-random"
   "mirage-stack"
   "mirage-time"
-  "paf"              {>= "0.0.9"}
-  "paf-le"           {>= "0.0.9"}
+  "paf"              {>= "0.1.0"}
+  "paf-le"           {>= "0.1.0"}
   "x509"
-]
-
-pin-depends: [
-  [ "paf.dev" "git+https://github.com/dinosaure/paf-le-chien.git#c44dbb29e23449e247ffeb06d865c9a2965fcbd0" ]
-  [ "paf-le.dev" "git+https://github.com/dinosaure/paf-le-chien.git#c44dbb29e23449e247ffeb06d865c9a2965fcbd0" ]
 ]

--- a/lib/certif.mli
+++ b/lib/certif.mli
@@ -18,14 +18,14 @@ module Make
 
   val thread_for 
     :  Lwt_mutex.t
-    -> (X509.Certificate.t * X509.Private_key.t)
+    -> Value.own_cert
     -> ?tries:int
     -> ?production:bool
     -> ?email:Emile.mailbox
     -> ?account_seed:string
     -> ?certificate_seed:string
     -> ((Tls.Config.own_cert, [> `Certificate_unavailable_for of [ `host ] Domain_name.t
-                              |  `Invalid_certificate of X509.Certificate.t ]) result
+                              |  `Invalid_certificate of Value.own_cert ]) result
         -> ([ `Ready ] -> 'a Lwt.t) Lwt.t)
     -> Stack.t
     -> ([ `Ready ] -> 'a Lwt.t)

--- a/lib/contruno.ml
+++ b/lib/contruno.ml
@@ -201,15 +201,15 @@ module Make0
         Paf.run (module Httpaf_client_connection) ~sleep:Time.sleep_ns conn (R.T flow)
 
   let transmit
-    : [ `read ] H2.Body.t -> [ `write ] H2.Body.t -> unit
+    : H2.Body.Reader.t -> H2.Body.Writer.t -> unit
     = fun src dst ->
       let rec on_eof () =
-        H2.Body.close_writer dst ;
-        H2.Body.close_reader src (* XXX(dinosaure): double-close? *)
+        H2.Body.Writer.close dst ;
+        H2.Body.Reader.close src (* XXX(dinosaure): double-close? *)
       and on_read buf ~off ~len =
-        H2.Body.write_bigstring dst ~off ~len buf ;
-        H2.Body.schedule_read src ~on_eof ~on_read in
-      H2.Body.schedule_read src ~on_eof ~on_read
+        H2.Body.Writer.write_bigstring dst ~off ~len buf ;
+        H2.Body.Reader.schedule_read src ~on_eof ~on_read in
+      H2.Body.Reader.schedule_read src ~on_eof ~on_read
 
   let http_2_0_response_handler reqd : H2.Client_connection.response_handler = fun resp src ->
     let dst = H2.Reqd.respond_with_streaming reqd resp in

--- a/lib/contruno.mli
+++ b/lib/contruno.mli
@@ -1,9 +1,15 @@
 module Certificate : sig
+  type certchain = Tls.Config.certchain
+
+  type own_cert = 
+    [ `Multiple of certchain list
+    | `Multiple_default of certchain * certchain list
+    | `Single of certchain ]
+
   type t =
-    { cert : X509.Certificate.t
-    ; pkey : X509.Private_key.t
-    ; ip   : Ipaddr.t
-    ; alpn : alpn list }
+    { own_cert : own_cert
+    ; ip       : Ipaddr.t
+    ; alpn     : alpn list }
   and alpn = HTTP_1_1 | H2
 
   include Irmin.Contents.S with type t := t

--- a/lib/dune
+++ b/lib/dune
@@ -24,4 +24,11 @@
  (name contruno)
  (public_name contruno)
  (modules contruno)
- (libraries contruno.certif contruno.value irmin-mirage-git art ipaddr x509 irmin))
+ (libraries
+  contruno.certif
+  contruno.value
+  irmin-mirage-git
+  art
+  ipaddr
+  x509
+  irmin))

--- a/lib/dune
+++ b/lib/dune
@@ -6,6 +6,7 @@
   rresult
   ca-certs-nss
   dns-client.mirage
+  contruno.value
   paf.mirage
   paf-le
   tcpip
@@ -17,10 +18,10 @@
  (name value)
  (public_name contruno.value)
  (modules value)
- (libraries rresult irmin ipaddr x509))
+ (libraries tls rresult irmin ipaddr x509))
 
 (library
  (name contruno)
  (public_name contruno)
  (modules contruno)
- (libraries certif value irmin-mirage-git art ipaddr x509 irmin))
+ (libraries contruno.certif contruno.value irmin-mirage-git art ipaddr x509 irmin))


### PR DESCRIPTION
/cc @verbosemode

This patch change the type of values stored into a Git repository so I will not try it today but the main change is keep all certificates given by let's encrypt instead one (as @verbosemode explained to me on Twitter). I'm not sure yet about this patch, mainly because I'm not sure about the aggregation of `hostnames` on all certificates given by one negociation with let's encrypt (such aggregation should finish with a `[ Strict of hostname ]`).

If it's the case, the rest of this PR should be safe - probably, we should check the calculation of the expiration of certificates, currently I took the earlier date from all certificate to know when and if the certificate becomes invalid.