### PR TITLE
Fix the way to get the hostname of a own_cert (and ignore R3 certificat

### DIFF
--- a/lib/certif.ml
+++ b/lib/certif.ml
@@ -104,10 +104,15 @@ module Make
       (Printexc.to_string exn)) ;
     Lwt.return_error (`Certificate_unavailable_for hostname)
 
+  let delete_r3_hostname =
+    let r3 = Domain_name.(host_exn (of_string_exn "R3")) in
+    List.filter (fun (_, r3') ->
+      not (Domain_name.equal r3' r3))
+
   let thread_for http own_cert ?tries ?production
     ?email ?account_seed ?certificate_seed
     upgrade stackv4v6 =
-      match Value.hostnames_of_own_cert own_cert with
+      match Value.hostnames_of_own_cert own_cert |> delete_r3_hostname with
       | [] ->
         Log.err (fun m -> m "The given certificate does not have a hostname.") ;
         Fmt.invalid_arg "Certificate without hostname"

--- a/lib/contruno.mli
+++ b/lib/contruno.mli
@@ -63,7 +63,7 @@ module Make
     -> Stack.t
     -> ((Ipaddr.t * int, flow) Hashtbl.t
         * Certificate.t Art.t
-        * ([ `raw ] Domain_name.t * ([ `Ready ] -> unit Lwt.t) Lwt.t) list
+        * ([ `host ] Domain_name.t * ([ `Ready ] -> unit Lwt.t) Lwt.t) list
         * upgrader) Lwt.t
 
   val create_upgrader
@@ -96,7 +96,7 @@ module Make
     -> branch:string
     -> remote:string
     -> Certificate.t Art.t
-    -> (([ `raw ] Domain_name.t * Certificate.t) option -> unit)
+    -> (([ `host ] Domain_name.t * Certificate.t) option -> unit)
     -> Stack.t
     -> unit
 end


### PR DESCRIPTION
Now, `own_cert` has 2 certificates, the hostname and R3. We fix how we recognize the hostname of a `own_cert`.