### PR TITLE
Fix reload

### DIFF
--- a/lib/contruno.ml
+++ b/lib/contruno.ml
@@ -277,7 +277,7 @@ module Make
     | Error _ -> Lwt.return_unit
     | Ok lst ->
       let f acc (name, kind) =
-        let name = Mirage_kv.Key.to_string name in
+        let name = Mirage_kv.Key.basename name in
         match kind, Result.bind (Domain_name.of_string name) Domain_name.host with
         | `Dictionary, _ -> Lwt.return acc
         | `Value, Error _ -> Lwt.return acc


### PR DESCRIPTION
**edit**: It turned out I had two issues with contruno's reload:
1. `Mirage_kv.Key.to_string` would add a prefix `"/"` to the git filenames, so contruno would reject them as invalid hostnames
2. Contruno would only pull from the update `stream` once, so further updates would not be detected