### PR TITLE
Redirect http to https

### DIFF
--- a/lib/certif.mli
+++ b/lib/certif.mli
@@ -6,20 +6,19 @@ module Make
   (Stack : Tcpip.Stack.V4V6)
 : sig
   val get_certificate_for
-    :  Lwt_mutex.t
-    -> ?tries:int
+    :  ?tries:int
     -> ?production:bool
     -> hostname:[ `host ] Domain_name.t
     -> ?email:Emile.mailbox
     -> ?account_seed:string
     -> ?certificate_seed:string
     -> Http_mirage_client.t
-    -> Stack.t
     -> (Tls.Config.own_cert, [> `Certificate_unavailable_for of [ `host ] Domain_name.t ]) result Lwt.t
 
+  val serve : Paf_mirage.Make(Stack.TCP).t Paf.service
+
   val thread_for 
-    :  Lwt_mutex.t
-    -> Value.own_cert
+    :  Value.own_cert
     -> ?tries:int
     -> ?production:bool
     -> ?email:Emile.mailbox
@@ -29,14 +28,13 @@ module Make
                               |  `Invalid_certificate of Value.own_cert ]) result
         -> ([ `Ready ] -> 'a Lwt.t) Lwt.t)
     -> Http_mirage_client.t
-    -> Stack.t
     -> ([ `Ready ] -> 'a Lwt.t)
-  (** [thread_for mutex (certificate, pk) k stack : ([ `Ready ] -> 'a Lwt.t)]
+  (** [thread_for (certificate, pk) k : ([ `Ready ] -> 'a Lwt.t)]
       creates a function that waits until the end of the given certificate
       (its expiration) to execute the continuation. If the certificate is
       active or expired, a time-out request to let's encrypt is made and the
       result is returned to the continuation.
 
-      A mutex is required to safely launch a server on [*:80] (and do the
-      let's encrypt challenge). *)
+      A server running on [*:80] is expected to be launched before,
+      using {!request_handler} to do the let's encrypt challenge. *)
 end

--- a/lib/contruno.ml
+++ b/lib/contruno.ml
@@ -382,7 +382,7 @@ module Make
            && name.[0] = 'R'
            && String.for_all is_digit (String.sub name 1 (String.length name - 1))))
 
-  let reasking_certificate http tree cfg invalid_certificate alpn stackv4v6 =
+  let reasking_certificate tree cfg invalid_certificate alpn =
     let { production; email; account_seed; certificate_seed; } = cfg in
     let hostname =
       Certificate.hostnames_of_own_cert invalid_certificate.Certificate.own_cert
@@ -390,8 +390,8 @@ module Make
       |> function
       | [ `Strict, hostname ] -> hostname
       | _ -> assert false in
-    Certif.get_certificate_for http ~tries:10
-      ~production ~hostname ?email ?account_seed ?certificate_seed alpn stackv4v6 >>= function
+    Certif.get_certificate_for ~tries:10
+      ~production ~hostname ?email ?account_seed ?certificate_seed alpn >>= function
     | Ok `None ->
       Log.warn (fun m -> m "We did not got a certificate for %a." Domain_name.pp hostname);
       Lwt.return (`Delete hostname) (* TODO *)
@@ -420,8 +420,8 @@ module Make
     | `Delete hostname ->
       Fmt.pf ppf "Delete certificate of %a" Domain_name.pp hostname
 
-  let reasking_and_upgrade store http tree cfg v alpn stackv4v6 =
-    reasking_certificate http tree cfg v alpn stackv4v6 >>= fun action ->
+  let reasking_and_upgrade store tree cfg v alpn =
+    reasking_certificate tree cfg v alpn >>= fun action ->
     Log.debug (fun m -> m "Compute action: %a" pp_action action) ;
     match action with
     | `Set (hostname, v) ->
@@ -434,7 +434,7 @@ module Make
       >|= R.reword_error (R.msgf "%a" Store.pp_write_error)
       >|= R.failwith_error_msg
 
-  let sanitize http store cfg alpn stackv4v6 =
+  let sanitize store cfg alpn =
     aggregate_certificates store >>= fun certificates ->
     Log.debug (fun m -> m "Got %d certificate(s)." (List.length certificates));
     let now = Ptime.v (Pclock.now_d_ps ()) in
@@ -455,7 +455,7 @@ module Make
         Log.err (fun m -> m "The given certificate handles multiples domains: %a." Fmt.(Dump.list Domain_name.pp) lst))
       valids;
     Lwt_list.iter_s
-      (fun v -> reasking_and_upgrade store http tree cfg v alpn stackv4v6) invalids >>= fun () ->
+      (fun v -> reasking_and_upgrade store tree cfg v alpn) invalids >>= fun () ->
     Lwt.return tree
 
   let _tls_edn, tls_protocol = Mimic.register ~name:"tls-with-reneg" (module TLS)
@@ -470,20 +470,20 @@ module Make
     Art.insert tree (Art.key (Domain_name.to_string hostname)) v ;
     Lwt.return_unit
 
-  let rec create_upgrader http conns tree ~ctx ~remote cfg alpn stackv4v6 =
+  let rec create_upgrader conns tree ~ctx ~remote cfg alpn =
     fun (hostname : Art.key) old_certificate : ([ `Ready ] -> unit Lwt.t) Lwt.t ->
     let { production; email; account_seed; certificate_seed; } = cfg in
     Log.debug (fun m -> m "We create a certificate upgrader for %s." (hostname :> string)) ;
-    let f = upgrade_and_renegociate http conns tree ~ctx ~remote cfg alpn stackv4v6 hostname old_certificate in
+    let f = upgrade_and_renegociate conns tree ~ctx ~remote cfg alpn hostname old_certificate in
     try
-      let fn = Certif.thread_for http
+      let fn = Certif.thread_for
         old_certificate.Certificate.own_cert
-        ~production ?email ?account_seed ?certificate_seed f alpn stackv4v6 in
+        ~production ?email ?account_seed ?certificate_seed f alpn in
       Lwt.return fn
     with exn ->
       Log.err (fun m -> m "Got an error for %s: %S" (hostname :> string) (Printexc.to_string exn)) ;
       Lwt.return (fun `Ready -> Lwt.return_unit)
-  and upgrade_and_renegociate http conns tree ~ctx ~remote cfg alpn stackv4v6 hostname old_certificate
+  and upgrade_and_renegociate conns tree ~ctx ~remote cfg alpn hostname old_certificate
     new_certificate : ([ `Ready ] -> unit Lwt.t) Lwt.t = match new_certificate with
     | Ok (#Certificate.own_cert as own_cert) ->
       ( try Art.remove tree hostname with _ -> () ) ;
@@ -493,7 +493,7 @@ module Make
           alpn= old_certificate.Certificate.alpn; } in
       renegociation tree conns >>= fun () ->
       set ~ctx remote tree (Domain_name.of_string_exn (hostname :> string)) v >>= fun () ->
-      create_upgrader http conns tree ~ctx ~remote cfg alpn stackv4v6 hostname v
+      create_upgrader conns tree ~ctx ~remote cfg alpn hostname v
     | Error (`Msg err) ->
       Log.err (fun m -> m "Got an error for %s when we re-asking a new certificate: %s." (hostname :> string) err) ;
       Lwt.return (fun `Ready -> Lwt.return_unit)
@@ -510,18 +510,18 @@ module Make
   type upgrader =
     [ `Upgrader of Art.key -> Certificate.t -> ([ `Ready ] -> unit Lwt.t) Lwt.t ]
 
-  let initialize http ~ctx ~remote cfg alpn stackv4v6 =
+  let initialize ~ctx ~remote cfg alpn =
     Git_kv.connect ctx remote >>= fun store -> 
     Log.debug (fun m -> m "Start to sanitize TLS certificates.") ;
-    sanitize http store cfg alpn stackv4v6 >>= fun tree ->
+    sanitize store cfg alpn >>= fun tree ->
     Log.debug (fun m -> m "TLS certificates sanitized.") ;
     let conns = Hashtbl.create 0x1000 in
     let f (hostname : Art.key) v acc =
       let hostname' = Domain_name.(host_exn (of_string_exn (hostname :> string))) in
-      (hostname', create_upgrader http conns tree ~ctx ~remote cfg alpn stackv4v6 hostname v) :: acc in
+      (hostname', create_upgrader conns tree ~ctx ~remote cfg alpn hostname v) :: acc in
     let ths = Art.iter ~f [] tree in
     let upgrader hostname v =
-      create_upgrader http conns tree ~ctx ~remote cfg alpn stackv4v6 hostname v in
+      create_upgrader conns tree ~ctx ~remote cfg alpn hostname v in
     Lwt.return (conns, tree, ths, `Upgrader upgrader)
 
   let info =
@@ -558,21 +558,7 @@ module Make
 
   let init ~port stackv4v6 = Paf.init ~port (Stack.tcp stackv4v6)
 
-  let redirect_http =
-    let error_handler _ ?request:_ _ _ = () in
-    let handler _flow _dst reqd =
-      let open Httpaf in
-      let req = Reqd.request reqd in
-      match Headers.get req.headers "Host" with
-      | None -> ()
-      | Some host ->
-        let location = "https://" ^ host ^ req.target in
-        let headers =
-          Headers.of_list [ "Location", location; "Content-Length", "0" ] in
-        let resp = Response.create ~headers `Moved_permanently in
-        Reqd.respond_with_string reqd resp ""
-    in
-    Paf.http_service ~error_handler handler
+  let serve_http = Certif.serve
 
   let alpn_protocols tree =
     let http_1_1 = ref false and h2 = ref false in

--- a/lib/contruno.mli
+++ b/lib/contruno.mli
@@ -36,11 +36,9 @@ module Make
     -> unit Lwt.t
 
   val sanitize
-    :  Lwt_mutex.t
-    -> Git_kv.t
+    :  Git_kv.t
     -> cfg
     -> Http_mirage_client.t
-    -> Stack.t
     -> Certificate.t Art.t Lwt.t
 
   val tls_protocol : (endpoint, flow) Mimic.protocol
@@ -49,26 +47,22 @@ module Make
     [ `Upgrader of Art.key -> Certificate.t -> ([ `Ready ] -> unit Lwt.t) Lwt.t ]
 
   val initialize
-    :  Lwt_mutex.t
-    -> ctx:Mimic.ctx
+    :  ctx:Mimic.ctx
     -> remote:string
     -> cfg
     -> Http_mirage_client.t
-    -> Stack.t
     -> ((Ipaddr.t * int, flow) Hashtbl.t
         * Certificate.t Art.t
         * ([ `host ] Domain_name.t * ([ `Ready ] -> unit Lwt.t) Lwt.t) list
         * upgrader) Lwt.t
 
   val create_upgrader
-    :  Lwt_mutex.t
-    -> (Ipaddr.t * int, flow) Hashtbl.t
+    :  (Ipaddr.t * int, flow) Hashtbl.t
     -> Certificate.t Art.t
     -> ctx:Mimic.ctx
     -> remote:string
     -> cfg
     -> Http_mirage_client.t
-    -> Stack.t
     -> Art.key
     -> Certificate.t
     -> ([ `Ready ] -> unit Lwt.t) Lwt.t
@@ -77,7 +71,7 @@ module Make
 
   val init : port:int -> Stack.t -> stack Lwt.t
 
-  val redirect_http : stack Paf.service
+  val serve_http : stack Paf.service
 
   val serve
     :  (Ipaddr.t * int, flow) Hashtbl.t

--- a/lib/contruno.mli
+++ b/lib/contruno.mli
@@ -77,6 +77,8 @@ module Make
 
   val init : port:int -> Stack.t -> stack Lwt.t
 
+  val redirect_http : stack Paf.service
+
   val serve
     :  (Ipaddr.t * int, flow) Hashtbl.t
     -> Certificate.t Art.t

--- a/unikernel/unikernel.ml
+++ b/unikernel/unikernel.ml
@@ -143,20 +143,19 @@ module Make
 
   let start _random _time () () stackv4v6 alpn ctx
     { K.remote; production; cert_seed; account_seed; email; pass; _ } =
-    let http = Lwt_mutex.create () in
+    let stop = Lwt_switch.create () in
+    init ~port:80 stackv4v6 >>= fun http_service ->
+    let `Initialized th_http = Paf.serve ~stop serve_http http_service in
     let cfg  = { Contruno.production
                ; email= Option.bind email (R.to_option <.> Emile.of_string)
                ; account_seed
                ; certificate_seed= cert_seed } in
     let stream, push = Lwt_stream.create () in
-    initialize http ~ctx ~remote cfg alpn stackv4v6
+    initialize ~ctx ~remote cfg alpn
     >>= fun (conns, tree, reneg_ths, `Upgrader upgrader) ->
     let service = serve conns tree (Stack.tcp stackv4v6) in
     add_hook ~pass ~ctx ~remote tree push stackv4v6 ;
-    init ~port:80 stackv4v6 >>= fun http_service ->
     init ~port:443 stackv4v6 >>= fun https_service ->
-    let stop = Lwt_switch.create () in
-    let `Initialized th_http = Paf.serve ~stop redirect_http http_service in
     let `Initialized th_https = Paf.serve ~stop service https_service in
     Lwt.join
       [ launch_reneg_ths ~stop ~upgrader reneg_ths stream


### PR DESCRIPTION
Since the readme configures iptables for ports 80 and 443, I thought that contruno would automatically upgrade http clients to https (but in practice contruno wasn't listening on port 80).

**edit:** oops, changed to draft because it actually interferes with let's encrypt, which uses port 80!